### PR TITLE
Feat/4.4 implement forgot password component

### DIFF
--- a/Shuttle-front/src/app/app.component.html
+++ b/Shuttle-front/src/app/app.component.html
@@ -4,4 +4,6 @@
   <!-- Put main routing component here (dynamically). -->
 
   <button mat-raised-button color="primary" (click)="helloBackend()">Say hi to the backend.</button>
+
 </router-outlet>
+<app-snack-bar></app-snack-bar>

--- a/Shuttle-front/src/app/app.module.ts
+++ b/Shuttle-front/src/app/app.module.ts
@@ -15,6 +15,7 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { LoginComponent } from './login/component/login/login.component';
 import { NavbarComponent } from './navbar/navbar.component';
 import { MaterialModule } from 'src/infrastructure/material.module';
+import { ForgotPasswordComponent } from './login/component/forgot-password/forgot-password.component';
 
 @NgModule({
     declarations: [
@@ -22,6 +23,7 @@ import { MaterialModule } from 'src/infrastructure/material.module';
         RegisterComponent,
         LoginComponent,
         NavbarComponent,
+        ForgotPasswordComponent,
     ],
     imports: [
         BrowserModule,

--- a/Shuttle-front/src/app/app.module.ts
+++ b/Shuttle-front/src/app/app.module.ts
@@ -6,17 +6,14 @@ import { AppRoutingModule } from 'src/infrastructure/app-routing.module';
 import { AppComponent } from './app.component';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
-import {MatToolbarModule} from '@angular/material/toolbar';
-import {MatButtonModule} from '@angular/material/button';
-import {MatInputModule} from '@angular/material/input';
 import { RegisterComponent } from './register/register.component'
 
-import { ReactiveFormsModule } from '@angular/forms';
 import { LoginComponent } from './login/component/login/login.component';
 import { NavbarComponent } from './navbar/navbar.component';
 import { MaterialModule } from 'src/infrastructure/material.module';
 import { ForgotPasswordComponent } from './login/component/forgot-password/forgot-password.component';
 import { ResetPasswordComponent } from './login/component/reset-password/reset-password.component';
+import { SharedModule } from './shared/shared.module';
 
 @NgModule({
     declarations: [
@@ -32,12 +29,8 @@ import { ResetPasswordComponent } from './login/component/reset-password/reset-p
         HttpClientModule,
         AppRoutingModule,
         BrowserAnimationsModule,
-
         MaterialModule,
-        MatToolbarModule,
-        MatButtonModule,
-        ReactiveFormsModule,
-        MatInputModule
+        SharedModule,
     ],
     providers: [],
     bootstrap: [AppComponent]

--- a/Shuttle-front/src/app/app.module.ts
+++ b/Shuttle-front/src/app/app.module.ts
@@ -16,6 +16,7 @@ import { LoginComponent } from './login/component/login/login.component';
 import { NavbarComponent } from './navbar/navbar.component';
 import { MaterialModule } from 'src/infrastructure/material.module';
 import { ForgotPasswordComponent } from './login/component/forgot-password/forgot-password.component';
+import { ResetPasswordComponent } from './login/component/reset-password/reset-password.component';
 
 @NgModule({
     declarations: [
@@ -24,6 +25,7 @@ import { ForgotPasswordComponent } from './login/component/forgot-password/forgo
         LoginComponent,
         NavbarComponent,
         ForgotPasswordComponent,
+        ResetPasswordComponent,
     ],
     imports: [
         BrowserModule,

--- a/Shuttle-front/src/app/login/component/forgot-password/forgot-password.component.css
+++ b/Shuttle-front/src/app/login/component/forgot-password/forgot-password.component.css
@@ -10,6 +10,14 @@
     width: 30%;
 }
 
+hr {
+    margin-bottom: 4em;
+}
+
+mat-form-field {
+    width: 100%;
+}
+
 h2 {
     font-size: 3em;
     text-transform: uppercase;

--- a/Shuttle-front/src/app/login/component/forgot-password/forgot-password.component.css
+++ b/Shuttle-front/src/app/login/component/forgot-password/forgot-password.component.css
@@ -1,0 +1,27 @@
+#password-reset-confirmation-form {
+    display: flex;
+}
+
+#password-reset-confirmation-form>mat-card {
+    padding: 48px 16px;
+    display: inline-block;
+    margin: auto;
+    border-radius: 16px;
+    width: 30%;
+}
+
+h2 {
+    font-size: 3em;
+    text-transform: uppercase;
+    margin-bottom: 7%;
+}
+
+button {
+    margin-bottom: 1.5em;
+    margin-top: 1.5em;
+    width: 100%;
+}
+
+.rightAlign {
+    float: right;
+}

--- a/Shuttle-front/src/app/login/component/forgot-password/forgot-password.component.css
+++ b/Shuttle-front/src/app/login/component/forgot-password/forgot-password.component.css
@@ -28,6 +28,8 @@ button {
     margin-bottom: 1.5em;
     margin-top: 1.5em;
     width: 100%;
+    padding: 1.5em;
+    font-size: larger;
 }
 
 .rightAlign {

--- a/Shuttle-front/src/app/login/component/forgot-password/forgot-password.component.html
+++ b/Shuttle-front/src/app/login/component/forgot-password/forgot-password.component.html
@@ -1,15 +1,25 @@
 <div id="password-reset-confirmation-form">
     <mat-card>
-        <h2>Reset Password</h2>
-        <hr/>
-        <p>
-            Forgot password?
+
+        <form [formGroup]="formGroup" (ngSubmit)="sendPasswordResetLink()">
+            <h2>Reset Password</h2>
+            <hr/>
+
+            <p>
+                Forgot password?
+                <br/>
+                Enter your e-mail and we'll send you a link where you can enter a new password.
+            </p>
+
             <br/>
-            We'll send you a link to <b>{{ myEmail }}</b>, where you can enter a new password.
-        </p>
-        <p>
-            <button mat-raised-button color="primary" (click)="sendPasswordResetLink()">Send</button>
-        </p>
+
+            <mat-form-field appearance="outline">
+                <mat-label>Enter your email</mat-label>
+                <input matInput name="email" type="email" formControlName="email" />
+            </mat-form-field>
+
+            <button id="submitButton" mat-raised-button type="submit" color="primary" [disabled]="!formGroup.valid">Submit</button>
+        </form>
         <p class="rightAlign">
             <a routerLink="/login">Back to Login</a>
         </p>

--- a/Shuttle-front/src/app/login/component/forgot-password/forgot-password.component.html
+++ b/Shuttle-front/src/app/login/component/forgot-password/forgot-password.component.html
@@ -1,14 +1,11 @@
 <div id="password-reset-confirmation-form">
     <mat-card>
-
         <form [formGroup]="formGroup" (ngSubmit)="sendPasswordResetLink()">
-            <h2>Reset Password</h2>
+            <h2>Forgot Password?</h2>
             <hr/>
 
             <p>
-                Forgot password?
-                <br/>
-                Enter your e-mail and we'll send you a link where you can enter a new password.
+                We'll send  a to your email where you can enter a new password.
             </p>
 
             <br/>

--- a/Shuttle-front/src/app/login/component/forgot-password/forgot-password.component.html
+++ b/Shuttle-front/src/app/login/component/forgot-password/forgot-password.component.html
@@ -1,0 +1,17 @@
+<div id="password-reset-confirmation-form">
+    <mat-card>
+        <h2>Reset Password</h2>
+        <hr/>
+        <p>
+            Forgot password?
+            <br/>
+            We'll send you a link to <b>{{ myEmail }}</b>, where you can enter a new password.
+        </p>
+        <p>
+            <button mat-raised-button color="primary" (click)="sendPasswordResetLink()">Send</button>
+        </p>
+        <p class="rightAlign">
+            <a routerLink="/login">Back to Login</a>
+        </p>
+    </mat-card>
+</div>

--- a/Shuttle-front/src/app/login/component/forgot-password/forgot-password.component.html
+++ b/Shuttle-front/src/app/login/component/forgot-password/forgot-password.component.html
@@ -5,7 +5,7 @@
             <hr/>
 
             <p>
-                We'll send  a to your email where you can enter a new password.
+                We'll send a link to your email where you can enter a new password.
             </p>
 
             <br/>

--- a/Shuttle-front/src/app/login/component/forgot-password/forgot-password.component.spec.ts
+++ b/Shuttle-front/src/app/login/component/forgot-password/forgot-password.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ForgotPasswordComponent } from './forgot-password.component';
+
+describe('ResetPasswordComponent', () => {
+  let component: ForgotPasswordComponent;
+  let fixture: ComponentFixture<ForgotPasswordComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ForgotPasswordComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ForgotPasswordComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/Shuttle-front/src/app/login/component/forgot-password/forgot-password.component.ts
+++ b/Shuttle-front/src/app/login/component/forgot-password/forgot-password.component.ts
@@ -1,0 +1,22 @@
+import { Component } from '@angular/core';
+
+@Component({
+    selector: 'app-forgot-password',
+    templateUrl: './forgot-password.component.html',
+    styleUrls: ['./forgot-password.component.css']
+})
+export class ForgotPasswordComponent {
+    myEmail: string = "example@mail.com"; // TODO: Fetch from session.
+
+    sendPasswordResetLink() {
+        throw new Error('Method not implemented.');
+    }
+
+    ngOnInit() {
+        document.body.className = "body-gradient2"; // Defined in src/styles.css
+    }
+
+    ngOnDestroy() {
+        document.body.className = "";
+    }
+}

--- a/Shuttle-front/src/app/login/component/forgot-password/forgot-password.component.ts
+++ b/Shuttle-front/src/app/login/component/forgot-password/forgot-password.component.ts
@@ -1,5 +1,7 @@
 import { Component } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { Router } from '@angular/router';
+import { SharedService } from 'src/app/shared/shared.service';
 
 @Component({
     selector: 'app-forgot-password',
@@ -9,7 +11,7 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 export class ForgotPasswordComponent {
     formGroup: FormGroup;
 
-    constructor(private readonly formBuilder: FormBuilder) {
+    constructor(private readonly formBuilder: FormBuilder, private router: Router, private sharedService: SharedService) {
         this.formGroup = formBuilder.group({
             email: ['', [Validators.required, Validators.email]],
         });
@@ -18,7 +20,11 @@ export class ForgotPasswordComponent {
     sendPasswordResetLink() {
         if (this.formGroup.valid) {
             let email = this.formGroup.getRawValue()['email'];
-            console.log("Send link to " + email);
+
+            this.sharedService.showSnackBar("An e-mail has been sent to " + email + ".", 5000);
+            this.router.navigate(["/login"]);
+
+            // TODO: Send it.
         }
     }
 

--- a/Shuttle-front/src/app/login/component/forgot-password/forgot-password.component.ts
+++ b/Shuttle-front/src/app/login/component/forgot-password/forgot-password.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 
 @Component({
     selector: 'app-forgot-password',
@@ -6,10 +7,19 @@ import { Component } from '@angular/core';
     styleUrls: ['./forgot-password.component.css']
 })
 export class ForgotPasswordComponent {
-    myEmail: string = "example@mail.com"; // TODO: Fetch from session.
+    formGroup: FormGroup;
+
+    constructor(private readonly formBuilder: FormBuilder) {
+        this.formGroup = formBuilder.group({
+            email: ['', [Validators.required, Validators.email]],
+        });
+    }
 
     sendPasswordResetLink() {
-        throw new Error('Method not implemented.');
+        if (this.formGroup.valid) {
+            let email = this.formGroup.getRawValue()['email'];
+            console.log("Send link to " + email);
+        }
     }
 
     ngOnInit() {

--- a/Shuttle-front/src/app/login/component/login/login.component.html
+++ b/Shuttle-front/src/app/login/component/login/login.component.html
@@ -19,7 +19,7 @@
 			</mat-form-field>
 			<br />
 			<button id="submitButton" mat-raised-button type="submit" color="primary" [disabled]="!formGroup.valid">Log in</button>
-			<p><a class="rightAlign" href="#">Forgot password?</a></p>
+			<p><a class="rightAlign" routerLink="/forgot-password">Forgot password?</a></p>
 			<br />
 
 			<!-- TODO: Route to registration -->

--- a/Shuttle-front/src/app/login/component/login/login.component.ts
+++ b/Shuttle-front/src/app/login/component/login/login.component.ts
@@ -2,32 +2,32 @@ import { Component } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 
 @Component({
-	selector: 'app-login',
-	templateUrl: './login.component.html',
-	styleUrls: ['./login.component.css'],
+    selector: 'app-login',
+    templateUrl: './login.component.html',
+    styleUrls: ['./login.component.css'],
 })
 export class LoginComponent {
-	formGroup: FormGroup;
+    formGroup: FormGroup;
 
-	onLoginSubmit(): void {
-		if (this.formGroup.valid) {
-			console.log(this.formGroup.getRawValue());
-		}
-	}
+    onLoginSubmit(): void {
+        if (this.formGroup.valid) {
+            console.log(this.formGroup.getRawValue());
+        }
+    }
 
-	constructor(private readonly formBuilder: FormBuilder) {
-		this.formGroup = formBuilder.group({
-			email: ['', [Validators.required, Validators.email]],
-			password: ['', [Validators.required]],
-		});
-	}
+    constructor(private readonly formBuilder: FormBuilder) {
+        this.formGroup = formBuilder.group({
+            email: ['', [Validators.required, Validators.email]],
+            password: ['', [Validators.required]],
+        });
+    }
 
-  ngOnInit() {
-		// HACK: Is there a better way to dynamically change body style from a component?
-		document.body.className = "body-gradient1"; // Defined in src/styles.css
-  }
+    ngOnInit() {
+        // HACK: Is there a better way to dynamically change body style from a component?
+        document.body.className = "body-gradient1"; // Defined in src/styles.css
+    }
 
-	ngOnDestroy() {
-		document.body.className = "";
-	}
+    ngOnDestroy() {
+        document.body.className = "";
+    }
 }

--- a/Shuttle-front/src/app/login/component/reset-password/reset-password.component.css
+++ b/Shuttle-front/src/app/login/component/reset-password/reset-password.component.css
@@ -44,7 +44,3 @@ form button, #resetPasswordExpired button {
 .rightAlign {
     float: right;
 }
-
-#resetPasswordExpired {
-
-}

--- a/Shuttle-front/src/app/login/component/reset-password/reset-password.component.css
+++ b/Shuttle-front/src/app/login/component/reset-password/reset-password.component.css
@@ -1,0 +1,50 @@
+#resetPassword, #resetPasswordExpired {
+    display: flex;
+}
+
+#resetPassword>mat-card, #resetPasswordExpired>mat-card {
+    padding: 48px 16px;
+    display: inline-block;
+    margin: auto;
+    border-radius: 16px;
+    width: 30%;
+}
+
+mat-form-field {
+    width: 100%;
+}
+
+form h2 {
+    font-size: 3em;
+    text-transform: uppercase;
+}
+
+hr {
+    margin-bottom: 4em;
+}
+
+form button, #resetPasswordExpired button {
+    margin-bottom: 1em;
+    width: 100%;
+}
+
+#submitButton {
+    padding: 1.5em;
+    font-size: larger;
+}
+
+#signInWithGoogle {
+    background-color: #317CD8;
+}
+
+#signInWithFacebook {
+    background-color: #3554C0;
+}
+
+.rightAlign {
+    float: right;
+}
+
+#resetPasswordExpired {
+
+}

--- a/Shuttle-front/src/app/login/component/reset-password/reset-password.component.html
+++ b/Shuttle-front/src/app/login/component/reset-password/reset-password.component.html
@@ -1,0 +1,36 @@
+<!-- Keep the two <div> elements completely disjoint -->
+
+<div id="resetPassword" *ngIf="!resetLinkExpired()">
+    <mat-card>
+        <form [formGroup]="formGroup" (ngSubmit)="updateNewPassword()">
+            <h2>Reset Password</h2>
+            <hr/>
+
+            <mat-form-field appearance="outline">
+                <mat-label>Enter new password</mat-label>
+                <input matInput name="password" type="password" formControlName="password" />
+            </mat-form-field>
+            <br />
+            <mat-form-field appearance="outline">
+                <mat-label>Confirm new password</mat-label>
+                <input matInput name="confirmPassword" type="password" formControlName="confirmPassword" />
+            </mat-form-field>
+            <br />
+            <button id="submitButton" mat-raised-button type="submit" color="primary" [disabled]="!formGroup.valid">Submit</button>
+        </form>
+    </mat-card>
+</div>
+
+<!-- ^ Valid password reset link -->
+<!-- v Invalid password reset link -->
+
+<div id="resetPasswordExpired" *ngIf="resetLinkExpired()">
+    <mat-card>
+        <p>
+            Link has expired.
+        </p>
+        <hr/>
+        <button mat-raised-button color="primary" routerLink="/login">Back to login</button>
+    </mat-card>
+
+</div>

--- a/Shuttle-front/src/app/login/component/reset-password/reset-password.component.spec.ts
+++ b/Shuttle-front/src/app/login/component/reset-password/reset-password.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ResetPasswordComponent } from './reset-password.component';
+
+describe('ResetPasswordComponent', () => {
+  let component: ResetPasswordComponent;
+  let fixture: ComponentFixture<ResetPasswordComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ResetPasswordComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ResetPasswordComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/Shuttle-front/src/app/login/component/reset-password/reset-password.component.ts
+++ b/Shuttle-front/src/app/login/component/reset-password/reset-password.component.ts
@@ -39,8 +39,7 @@ export class ResetPasswordComponent implements OnInit {
     }
 
     decodeKey(): string {
-        // TODO: Hardcoding Base64 removes trailing '==' so we add it manually.
-        return window.atob(this.key + "==");
+        return window.atob(this.key);
     }
 
     ngOnInit() {

--- a/Shuttle-front/src/app/login/component/reset-password/reset-password.component.ts
+++ b/Shuttle-front/src/app/login/component/reset-password/reset-password.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { FormGroup, FormBuilder, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 
@@ -7,7 +7,7 @@ import { Router } from '@angular/router';
   templateUrl: './reset-password.component.html',
   styleUrls: ['./reset-password.component.css']
 })
-export class ResetPasswordComponent {
+export class ResetPasswordComponent implements OnInit {
     /*
         This component can only be entered from a link.
         With the link should come some encrypted key from
@@ -45,7 +45,6 @@ export class ResetPasswordComponent {
         if (this.formGroup.valid) {
             let password = this.formGroup.getRawValue()['password'];
             console.log("Update user " + this.getUserEmail() + " with new password " + password);
-
             this.router.navigate(["/login"]);
         }
     }

--- a/Shuttle-front/src/app/login/component/reset-password/reset-password.component.ts
+++ b/Shuttle-front/src/app/login/component/reset-password/reset-password.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { FormGroup, FormBuilder, Validators } from '@angular/forms';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 
 @Component({
   selector: 'app-reset-password',
@@ -14,11 +14,16 @@ export class ResetPasswordComponent implements OnInit {
         which we fetch the user's email and let him actually
         change the password. Otherwise, show him that the
         link has expired.
+
+        Potential solution: Add key in URL with user e-mail
+        and expiration date. Without the key, router redirects
+        to login. Check app-routing.module.ts.
     */
 
+    private key: string = "";
     formGroup: FormGroup;
 
-    constructor(private readonly formBuilder: FormBuilder, private router: Router) {
+    constructor(private readonly formBuilder: FormBuilder, private router: Router, private route: ActivatedRoute) {
         this.formGroup = formBuilder.group({
             password: ['', [Validators.required]],
             confirmPassword: ['', [Validators.required]],
@@ -33,8 +38,22 @@ export class ResetPasswordComponent implements OnInit {
         return false;
     }
 
+    decodeKey(): string {
+        // TODO: Hardcoding Base64 removes trailing '==' so we add it manually.
+        return window.atob(this.key + "==");
+    }
+
     ngOnInit() {
         document.body.className = "body-gradient1"; // Defined in src/styles.css
+
+        this.route.params.subscribe(params => {
+            if (params['key'] != undefined) {
+                this.key = params['key'];
+                console.log(this.decodeKey());
+            } else {
+                this.router.navigate(["/login"]);
+            }
+        });
     }
 
     ngOnDestroy() {

--- a/Shuttle-front/src/app/login/component/reset-password/reset-password.component.ts
+++ b/Shuttle-front/src/app/login/component/reset-password/reset-password.component.ts
@@ -1,0 +1,52 @@
+import { Component } from '@angular/core';
+import { FormGroup, FormBuilder, Validators } from '@angular/forms';
+import { Router } from '@angular/router';
+
+@Component({
+  selector: 'app-reset-password',
+  templateUrl: './reset-password.component.html',
+  styleUrls: ['./reset-password.component.css']
+})
+export class ResetPasswordComponent {
+    /*
+        This component can only be entered from a link.
+        With the link should come some encrypted key from
+        which we fetch the user's email and let him actually
+        change the password. Otherwise, show him that the
+        link has expired.
+    */
+
+    formGroup: FormGroup;
+
+    constructor(private readonly formBuilder: FormBuilder, private router: Router) {
+        this.formGroup = formBuilder.group({
+            password: ['', [Validators.required]],
+            confirmPassword: ['', [Validators.required]],
+        });
+    }
+
+    getUserEmail(): string {
+        return "person@example.org";
+    }
+
+    resetLinkExpired(): boolean {
+        return false;
+    }
+
+    ngOnInit() {
+        document.body.className = "body-gradient1"; // Defined in src/styles.css
+    }
+
+    ngOnDestroy() {
+        document.body.className = "";
+    }
+
+    updateNewPassword() {
+        if (this.formGroup.valid) {
+            let password = this.formGroup.getRawValue()['password'];
+            console.log("Update user " + this.getUserEmail() + " with new password " + password);
+
+            this.router.navigate(["/login"]);
+        }
+    }
+}

--- a/Shuttle-front/src/app/login/component/reset-password/reset-password.component.ts
+++ b/Shuttle-front/src/app/login/component/reset-password/reset-password.component.ts
@@ -2,10 +2,12 @@ import { Component, OnInit } from '@angular/core';
 import { FormGroup, FormBuilder, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 
+import { EqualsValidator } from 'src/app/shared/validators/EqualsValidator';
+
 @Component({
-  selector: 'app-reset-password',
-  templateUrl: './reset-password.component.html',
-  styleUrls: ['./reset-password.component.css']
+    selector: 'app-reset-password',
+    templateUrl: './reset-password.component.html',
+    styleUrls: ['./reset-password.component.css']
 })
 export class ResetPasswordComponent implements OnInit {
     /*
@@ -24,9 +26,11 @@ export class ResetPasswordComponent implements OnInit {
     formGroup: FormGroup;
 
     constructor(private readonly formBuilder: FormBuilder, private router: Router, private route: ActivatedRoute) {
-        this.formGroup = formBuilder.group({
+        this.formGroup = this.formBuilder.group({
             password: ['', [Validators.required]],
             confirmPassword: ['', [Validators.required]],
+        }, {
+            validator: EqualsValidator('password', 'confirmPassword')
         });
     }
 

--- a/Shuttle-front/src/app/navbar/navbar.component.ts
+++ b/Shuttle-front/src/app/navbar/navbar.component.ts
@@ -1,5 +1,4 @@
-import { Attribute, Component, OnInit } from '@angular/core';
-import { MatButton } from '@angular/material/button';
+import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 
 @Component({
@@ -18,7 +17,7 @@ export class NavbarComponent implements OnInit {
 
   loginRoute() {
     this.router.navigate(["/login"]);
-  
+
   }
   registerRoute() {
     this.router.navigate(["/register"]);

--- a/Shuttle-front/src/app/shared/shared.module.ts
+++ b/Shuttle-front/src/app/shared/shared.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SnackBarComponent } from './snack-bar/snack-bar.component';
+
+@NgModule({
+  declarations: [
+    SnackBarComponent
+  ],
+  imports: [
+    CommonModule
+  ],
+  exports: [
+    SnackBarComponent
+  ]
+})
+export class SharedModule { }

--- a/Shuttle-front/src/app/shared/shared.service.spec.ts
+++ b/Shuttle-front/src/app/shared/shared.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { SharedService } from './shared.service';
+
+describe('SharedService', () => {
+  let service: SharedService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(SharedService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/Shuttle-front/src/app/shared/shared.service.ts
+++ b/Shuttle-front/src/app/shared/shared.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SharedService {
+    private snackMessage$ = new BehaviorSubject<any>({});
+    constructor() { }
+
+    showSnackBar(message: string, duration: number) {
+        this.snackMessage$.next({
+            "message": message,
+            "duration": duration,
+        });
+    }
+
+    getSnackMessage(): Observable<any> {
+        return this.snackMessage$.asObservable();
+    }
+}

--- a/Shuttle-front/src/app/shared/snack-bar/snack-bar.component.spec.ts
+++ b/Shuttle-front/src/app/shared/snack-bar/snack-bar.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SnackBarComponent } from './snack-bar.component';
+
+describe('SnackBarComponent', () => {
+  let component: SnackBarComponent;
+  let fixture: ComponentFixture<SnackBarComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ SnackBarComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(SnackBarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/Shuttle-front/src/app/shared/snack-bar/snack-bar.component.ts
+++ b/Shuttle-front/src/app/shared/snack-bar/snack-bar.component.ts
@@ -1,0 +1,24 @@
+import { Component, OnInit } from '@angular/core';
+import { SharedService } from '../shared.service';
+import { MatSnackBar } from '@angular/material/snack-bar';
+
+@Component({
+  selector: 'app-snack-bar',
+  templateUrl: './snack-bar.component.html',
+  styleUrls: ['./snack-bar.component.css']
+})
+export class SnackBarComponent implements OnInit {
+    constructor(private sharedService: SharedService, private snackBar: MatSnackBar) {
+
+    }
+
+    ngOnInit() {
+        this.sharedService.getSnackMessage().subscribe((val) => {
+            if (val.message != undefined && val.duration != undefined) {
+                this.snackBar.open(val.message, '', {
+                    duration: val.duration
+                });
+            }
+        });
+    }
+}

--- a/Shuttle-front/src/app/shared/validators/EqualsValidator.ts
+++ b/Shuttle-front/src/app/shared/validators/EqualsValidator.ts
@@ -1,0 +1,18 @@
+import { FormGroup } from "@angular/forms";
+
+export function EqualsValidator(control1name: string, control2name: string) {
+    return (formGroup: FormGroup) => {
+        const control1 = formGroup.controls[control1name];
+        const control2 = formGroup.controls[control2name];
+
+        if (control1.errors && !control2.errors?.["equalsValidator"]) {
+            return;
+        }
+
+        if (control1.value !== control2.value) {
+            control2.setErrors({ equalsValidator: true });
+        } else {
+            control2.setErrors(null);
+        }
+    }
+}

--- a/Shuttle-front/src/infrastructure/app-routing.module.ts
+++ b/Shuttle-front/src/infrastructure/app-routing.module.ts
@@ -1,11 +1,13 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { LoginComponent } from 'src/app/login/component/login/login.component';
+import { ForgotPasswordComponent } from 'src/app/login/component/forgot-password/forgot-password.component';
 import { RegisterComponent } from 'src/app/register/register.component';
 
 const routes: Routes = [
 	{path: "login", component: LoginComponent},
   {path: "register", component: RegisterComponent},
+  {path: 'forgot-password', component: ForgotPasswordComponent},
 ];
 
 @NgModule({

--- a/Shuttle-front/src/infrastructure/app-routing.module.ts
+++ b/Shuttle-front/src/infrastructure/app-routing.module.ts
@@ -3,11 +3,13 @@ import { RouterModule, Routes } from '@angular/router';
 import { LoginComponent } from 'src/app/login/component/login/login.component';
 import { ForgotPasswordComponent } from 'src/app/login/component/forgot-password/forgot-password.component';
 import { RegisterComponent } from 'src/app/register/register.component';
+import { ResetPasswordComponent } from 'src/app/login/component/reset-password/reset-password.component';
 
 const routes: Routes = [
 	{path: "login", component: LoginComponent},
   {path: "register", component: RegisterComponent},
   {path: 'forgot-password', component: ForgotPasswordComponent},
+  {path: 'reset-password', component: ResetPasswordComponent},
 ];
 
 @NgModule({

--- a/Shuttle-front/src/infrastructure/app-routing.module.ts
+++ b/Shuttle-front/src/infrastructure/app-routing.module.ts
@@ -9,7 +9,8 @@ const routes: Routes = [
 	{path: "login", component: LoginComponent},
   {path: "register", component: RegisterComponent},
   {path: 'forgot-password', component: ForgotPasswordComponent},
-  {path: 'reset-password', component: ResetPasswordComponent},
+  {path: 'reset-password', redirectTo: 'login'},
+  {path: 'reset-password/:key', component: ResetPasswordComponent},
 ];
 
 @NgModule({

--- a/Shuttle-front/src/infrastructure/material.module.ts
+++ b/Shuttle-front/src/infrastructure/material.module.ts
@@ -7,6 +7,7 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { MatIconModule } from '@angular/material/icon';
 import { FormsModule } from '@angular/forms';
 import { MatCardModule } from '@angular/material/card'
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 
 @NgModule({
 	imports: [
@@ -18,6 +19,11 @@ import { MatCardModule } from '@angular/material/card'
 		MatIconModule,
 		FormsModule,
 		MatCardModule,
+    MatToolbarModule,
+    MatButtonModule,
+    ReactiveFormsModule,
+    MatInputModule,
+    MatSnackBarModule,
 	],
 	exports: [
 		MatToolbarModule,
@@ -28,6 +34,11 @@ import { MatCardModule } from '@angular/material/card'
 		MatIconModule,
 		FormsModule,
 		MatCardModule,
+    MatToolbarModule,
+    MatButtonModule,
+    ReactiveFormsModule,
+    MatInputModule,
+    MatSnackBarModule,
 	],
   })
   export class MaterialModule {}

--- a/Shuttle-front/src/styles.css
+++ b/Shuttle-front/src/styles.css
@@ -13,6 +13,11 @@ body {
   background: linear-gradient(311deg, rgba(14,67,115,1) 0%, rgba(0,254,255,1) 100%);
 }
 
+.body-gradient2 {
+    background: rgb(0,254,255,1);
+    background: linear-gradient(311deg, rgba(0,254,255,1) 0%, rgba(14,67,115,1) 100%);
+}
+
 /* TODO: Remove this */
 nav {
 	background-color: white;


### PR DESCRIPTION
Closes #12.
Closes #13.

Manual functionality test
-------------------------

`/login` -> 'Forgot Password?' screen

Enter manually:

`/password-reset` redirects to the login screen (key required).
`/password-reset/ZW1haWw9Ym9iam9uZXNAZXhhbXBsZS5vcmcsZXhwaXJlcz0xMy4xMi4yMDIyQDE0OjUwOjEy` decodes the key in console (the scheme isn't final, but more of a proof of concept).

Other
-----

Also, `snackBar` implemented in `shared` module. Usage through injected sharedService:

```ts
this.sharedService.showSnackBar("Message for 5 seconds.", 5000);
```