### PR TITLE
Feat/2.2.7 driver activity

### DIFF
--- a/Shuttle-front/src/app/auth/auth.module.ts
+++ b/Shuttle-front/src/app/auth/auth.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { MaterialModule } from 'src/infrastructure/material.module';
 
 
 

--- a/Shuttle-front/src/app/auth/auth.service.ts
+++ b/Shuttle-front/src/app/auth/auth.service.ts
@@ -4,6 +4,8 @@ import {Injectable} from '@angular/core';
 import {BehaviorSubject, Observable} from 'rxjs';
 import {environment} from 'src/environments/environment';
 import {JwtHelperService} from '@auth0/angular-jwt';
+import { UserService } from '../user/user.service';
+import { SharedService } from '../shared/shared.service';
 
 @Injectable({
     providedIn: 'root',
@@ -17,7 +19,7 @@ export class AuthService {
     user$ = new BehaviorSubject(null);
     userState$ = this.user$.asObservable();
 
-    constructor(private http: HttpClient) {
+    constructor(private http: HttpClient, private userService: UserService, private sharedService: SharedService) {
         this.user$.next(this.getRole());
     }
 
@@ -28,8 +30,16 @@ export class AuthService {
     }
 
     logout() {
-        localStorage.clear();
-        window.location.reload();
+        this.userService.setInactive(this.getUserId()).subscribe({
+            next: (result) => {
+                localStorage.clear();
+                window.location.reload();
+            },
+            error: (error) => {
+                console.error("Could not log out: " + error);
+                this.sharedService.showSnackBar("Could not sign out.", 3000);
+            }
+        })
     }
 
     getRole(): any {

--- a/Shuttle-front/src/app/auth/auth.service.ts
+++ b/Shuttle-front/src/app/auth/auth.service.ts
@@ -41,6 +41,14 @@ export class AuthService {
         return null;
     }
 
+    getUserId(): number {
+        if (this.isLoggedIn()) {
+            console.log("getUserId(): " + new JwtHelperService().decodeToken(localStorage.getItem('user')!).id);
+            return new JwtHelperService().decodeToken(localStorage.getItem('user')!).id;
+        }
+        return -1;
+    }
+
     getRoles(): string[] {
         if (this.isLoggedIn()) {
             const accessToken: any = localStorage.getItem('user');

--- a/Shuttle-front/src/app/driver/driver-home/driver-home.component.html
+++ b/Shuttle-front/src/app/driver/driver-home/driver-home.component.html
@@ -1,12 +1,9 @@
 <div id="root-card">
+    <button (click)="SendWorkHoursThing()">Send work hours thing</button>
     <div class="row">
-
-        <button (click)="SendWorkHoursThing()">Send work hours thing</button>
         <!-- Left side - map -->
         <div class="column left">
             <div id="map"></div>
-
-
         </div>
 
         <!-- Right side - info -->

--- a/Shuttle-front/src/app/driver/driver-home/driver-home.component.html
+++ b/Shuttle-front/src/app/driver/driver-home/driver-home.component.html
@@ -1,8 +1,12 @@
 <div id="root-card">
     <div class="row">
+
+        <button (click)="SendWorkHoursThing()">Send work hours thing</button>
         <!-- Left side - map -->
         <div class="column left">
             <div id="map"></div>
+
+
         </div>
 
         <!-- Right side - info -->
@@ -54,13 +58,13 @@
             <mat-divider></mat-divider>
 
             <div id="buttons-bottom">
-                <div *ngIf="state == State.RIDE_REQUEST"> 
+                <div *ngIf="state == State.RIDE_REQUEST">
                     <button mat-raised-button color="primary" (click)="beginRide()"><mat-icon>play_circle_filled</mat-icon> Begin ride</button>
                     <div><br/></div>
                     <button type="submit" mat-raised-button color="warn" (click)="openRejectionDialog()"><mat-icon>stop</mat-icon> Reject ride</button>
                 </div>
                 <div *ngIf="state == State.RIDE_IN_PROGRESS">
-                    <button mat-raised-button color="warn" (click)="finishRide()"><mat-icon>stop</mat-icon> Finish</button>   
+                    <button mat-raised-button color="warn" (click)="finishRide()"><mat-icon>stop</mat-icon> Finish</button>
                     <br/>
                     <p id="elapsed-time">
                         Elapsed time: <b>{{ timerText }}</b>

--- a/Shuttle-front/src/app/driver/driver-home/driver-home.component.ts
+++ b/Shuttle-front/src/app/driver/driver-home/driver-home.component.ts
@@ -150,13 +150,16 @@ export class DriverHomeComponent implements OnInit, OnDestroy, AfterViewInit {
     }
 
     private getElapsedTime(): string {
-        let timeDiffMs: number = Date.now() - new Date(this.ride!.startTime).getTime();
-        let time: string = new Date(timeDiffMs).toISOString().substr(11, 8);
+        if (this.ride) {
+            let timeDiffMs: number = Date.now() - new Date(this.ride!.startTime).getTime();
+            let time: string = new Date(timeDiffMs).toISOString().substr(11, 8);
 
-        if (time.substr(0, 2) == "00") {
-            time = time.substr(3, 5);
+            if (time.substr(0, 2) == "00") {
+                time = time.substr(3, 5);
+            }
+            return time;
         }
-        return time;
+        return "00:00";
     }
 
     openRejectionDialog(): void {

--- a/Shuttle-front/src/app/driver/driver-home/driver-home.component.ts
+++ b/Shuttle-front/src/app/driver/driver-home/driver-home.component.ts
@@ -1,3 +1,4 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { AfterViewInit, Component, OnDestroy, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import * as L from 'leaflet';
@@ -8,6 +9,7 @@ import { NavbarService } from 'src/app/navbar-module/navbar.service';
 import { Ride, RideRequestSingleLocation, RideService, RideStatus } from 'src/app/ride/ride.service';
 import { SharedService } from 'src/app/shared/shared.service';
 import { UserService } from 'src/app/user/user.service';
+import { environment } from 'src/environments/environment';
 import { RejectRideDialogComponent } from '../reject-ride-dialog/reject-ride-dialog.component';
 
 enum State {
@@ -31,8 +33,37 @@ export class DriverHomeComponent implements OnInit, OnDestroy, AfterViewInit {
     ride: Ride | null = null;
     timerText: string = "";
 
-    constructor(public dialog: MatDialog, private sharedService: SharedService, private rideService: RideService, private navbarService: NavbarService, private userService: UserService, private authService: AuthService) {
-        this.pull = interval(3 * 1000).pipe(startWith(0)).subscribe(() => {
+    SendWorkHoursThing() {
+        /// TODO : REMOVE
+
+        const url: string = "/api/driver/{id}/working-hour";
+        const id: number = this.authService.getUserId();
+        const page: number = 0;
+        const size: number = 12;
+        const from: string = "2022-12-28T17:09:55";
+        const to: string = "2022-12-29T12:00:00";
+
+
+        let params = new HttpParams().set('page', page).set('size', size).set('from', from).set('to', to);
+
+
+        const options: any = { responseType: 'json' };
+        this.httpClient.get(environment.serverOrigin + `api/driver/${id}/working-hour`, {params: params, observe: "body"}).subscribe({
+            next: (value) => {
+                console.log("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+                console.log(value);
+            },
+            error: (error) => {
+                console.error("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+                console.error(error);
+            }
+        });
+    }
+
+    constructor(
+        private httpClient: HttpClient, // TODO REMOVE THIS.
+        public dialog: MatDialog, private sharedService: SharedService, private rideService: RideService, private navbarService: NavbarService, private userService: UserService, private authService: AuthService) {
+        this.pull = interval(8 * 1000).pipe(startWith(0)).subscribe(() => {
             this.pullNewRideRequest();
         });
     }

--- a/Shuttle-front/src/app/driver/driver-home/driver-home.component.ts
+++ b/Shuttle-front/src/app/driver/driver-home/driver-home.component.ts
@@ -100,6 +100,9 @@ export class DriverHomeComponent implements OnInit, OnDestroy, AfterViewInit {
 
                 this.sharedService.showSnackBar("Ride started.", 4000);
                 console.log(response);
+
+                // Change activity to active
+                // Disable the activity changer.
             },
             error: (error) => {
                 this.sharedService.showSnackBar("Could not start the ride.", 4000);
@@ -112,14 +115,9 @@ export class DriverHomeComponent implements OnInit, OnDestroy, AfterViewInit {
         const obs = this.rideService.reject(this.ride!.id, reason);
         obs.subscribe({
             next: (response) => {
-                this.state = State.JUST_MAP;
-
-                if (this.mapRoute != null) {
-                    this.mapRoute.remove();
-                }
+                this.removeRideFromContext();
 
                 this.sharedService.showSnackBar("Ride request rejected.", 4000);
-                this.ride = null;
                 console.log(response);
             }, error: (error) => {
                 this.sharedService.showSnackBar("Could not cancel the ride.", 4000);
@@ -132,17 +130,23 @@ export class DriverHomeComponent implements OnInit, OnDestroy, AfterViewInit {
         const obs = this.rideService.end(this.ride!.id);
         obs.subscribe({
             next: (response) => {
-                this.state = State.JUST_MAP;
-                this.mapRoute!.remove();
+                this.removeRideFromContext();
 
                 this.sharedService.showSnackBar("Ride completed.", 4000);
-                this.ride = null;
                 console.log(response);
             }, error: (error) => {
                 this.sharedService.showSnackBar("Could not end the ride.", 4000);
                 console.error(error);
             }
         });
+    }
+
+    private removeRideFromContext() {
+        this.state = State.JUST_MAP;
+        this.mapRoute!.remove();
+        this.ride = null;
+
+        // Enable the activity changer.
     }
 
     private getElapsedTime(): string {

--- a/Shuttle-front/src/app/navbar-module/driver-navbar/driver-navbar.component.css
+++ b/Shuttle-front/src/app/navbar-module/driver-navbar/driver-navbar.component.css
@@ -42,11 +42,12 @@ mat-icon {
     color: white;
 }
 
-mat-slide-toggle {
-    color: white;
-
+.isActiveForm {
+    margin-top: 5px;
+    margin-left: 8px;
 }
 
-#slider-text {
+.isActiveForm span {
+    font-size: 1.25em;
     color: white;
 }

--- a/Shuttle-front/src/app/navbar-module/driver-navbar/driver-navbar.component.html
+++ b/Shuttle-front/src/app/navbar-module/driver-navbar/driver-navbar.component.html
@@ -21,7 +21,11 @@
         <button mat-icon-button (click)="info()">
             <mat-icon>account_circle</mat-icon>
         </button>
-        <mat-slide-toggle><span id="slider-text">Active</span></mat-slide-toggle>
+
+        <form class="isActiveForm" [formGroup]="formGroupIsActive">
+            <mat-slide-toggle formControlName="enableWifi"><span>Active</span></mat-slide-toggle>
+        </form>
+
         <button mat-flat-button class="button" id="sign-out" (click)="logout()">Sign out</button>
     </div>
 </mat-toolbar>

--- a/Shuttle-front/src/app/navbar-module/driver-navbar/driver-navbar.component.html
+++ b/Shuttle-front/src/app/navbar-module/driver-navbar/driver-navbar.component.html
@@ -23,7 +23,7 @@
         </button>
 
         <form class="isActiveForm" [formGroup]="formGroupIsActive">
-            <mat-slide-toggle formControlName="enableWifi"><span>Active</span></mat-slide-toggle>
+            <mat-slide-toggle formControlName="isActive" (change)="onToggleIsActive()"><span>Active</span></mat-slide-toggle>
         </form>
 
         <button mat-flat-button class="button" id="sign-out" (click)="logout()">Sign out</button>

--- a/Shuttle-front/src/app/navbar-module/driver-navbar/driver-navbar.component.ts
+++ b/Shuttle-front/src/app/navbar-module/driver-navbar/driver-navbar.component.ts
@@ -1,22 +1,39 @@
-import {Component} from '@angular/core';
+import {Component, OnInit} from '@angular/core';
 import { FormGroup, FormBuilder } from '@angular/forms';
 import {Router} from "@angular/router";
 import { AuthService } from 'src/app/auth/auth.service';
 import { UserService } from 'src/app/user/user.service';
+import { __values } from 'tslib';
 
 @Component({
     selector: 'app-driver-navbar',
     templateUrl: './driver-navbar.component.html',
     styleUrls: ['./driver-navbar.component.css']
 })
-export class DriverNavbarComponent {
+export class DriverNavbarComponent implements OnInit {
     formGroupIsActive: FormGroup;
 
     constructor(private readonly formBuilder: FormBuilder, private authService: AuthService, private router: Router, private userService: UserService) {
         this.formGroupIsActive = formBuilder.group({
-            isActive: [],
+            isActive: [true],
         });
     }
+
+    ngOnInit(): void {
+        // Re-fetch activity from the backend and update the slider.
+        let active: boolean = false;
+
+        this.userService.getActive(this.authService.getUserId()).subscribe({
+            next: (value) => {
+                active = value;
+                this.formGroupIsActive.setValue({'isActive': active});
+            },
+            error: (error) => {
+                console.error(error);
+            }
+        })
+    }
+
     logout() {
         this.authService.logout();
     }
@@ -32,8 +49,9 @@ export class DriverNavbarComponent {
     onToggleIsActive() {
         const id: number = this.authService.getUserId();
         const active: boolean = this.formGroupIsActive.getRawValue()['isActive'];
+        const newState: boolean = !active;
 
-        if (active) {
+        if (newState) {
             this.userService.setInactive(id).subscribe({
                 next: (value) => {
                     console.log("OK: " + value);

--- a/Shuttle-front/src/app/navbar-module/driver-navbar/driver-navbar.component.ts
+++ b/Shuttle-front/src/app/navbar-module/driver-navbar/driver-navbar.component.ts
@@ -2,6 +2,7 @@ import {Component} from '@angular/core';
 import { FormGroup, FormBuilder } from '@angular/forms';
 import {Router} from "@angular/router";
 import { AuthService } from 'src/app/auth/auth.service';
+import { UserService } from 'src/app/user/user.service';
 
 @Component({
     selector: 'app-driver-navbar',
@@ -11,9 +12,9 @@ import { AuthService } from 'src/app/auth/auth.service';
 export class DriverNavbarComponent {
     formGroupIsActive: FormGroup;
 
-    constructor(private readonly formBuilder: FormBuilder, private authService: AuthService, private router: Router) {
+    constructor(private readonly formBuilder: FormBuilder, private authService: AuthService, private router: Router, private userService: UserService) {
         this.formGroupIsActive = formBuilder.group({
-            isActive: [false],
+            isActive: [],
         });
     }
     logout() {
@@ -26,6 +27,31 @@ export class DriverNavbarComponent {
 
     info() {
         this.router.navigate(["driver/info"]);
+    }
+
+    onToggleIsActive() {
+        const id: number = this.authService.getUserId();
+        const active: boolean = this.formGroupIsActive.getRawValue()['isActive'];
+
+        if (active) {
+            this.userService.setInactive(id).subscribe({
+                next: (value) => {
+                    console.log("OK: " + value);
+                },
+                error: (error) => {
+                    console.error("NO:" + error);
+                }
+            });
+        } else {
+            this.userService.setActive(id).subscribe({
+                next: (value) => {
+                    console.log("OK: " + value);
+                },
+                error: (error) => {
+                    console.error("NO:" + error);
+                }
+            });
+        }
     }
 
 }

--- a/Shuttle-front/src/app/navbar-module/driver-navbar/driver-navbar.component.ts
+++ b/Shuttle-front/src/app/navbar-module/driver-navbar/driver-navbar.component.ts
@@ -1,4 +1,5 @@
 import {Component} from '@angular/core';
+import { FormGroup, FormBuilder } from '@angular/forms';
 import {Router} from "@angular/router";
 import { AuthService } from 'src/app/auth/auth.service';
 
@@ -8,10 +9,13 @@ import { AuthService } from 'src/app/auth/auth.service';
     styleUrls: ['./driver-navbar.component.css']
 })
 export class DriverNavbarComponent {
+    formGroupIsActive: FormGroup;
 
-    constructor(private router: Router, private authService: AuthService) {
+    constructor(private readonly formBuilder: FormBuilder, private authService: AuthService, private router: Router) {
+        this.formGroupIsActive = formBuilder.group({
+            isActive: [false],
+        });
     }
-
     logout() {
         this.authService.logout();
     }

--- a/Shuttle-front/src/app/navbar-module/navbar-module.module.ts
+++ b/Shuttle-front/src/app/navbar-module/navbar-module.module.ts
@@ -9,6 +9,7 @@ import {MatButtonModule} from "@angular/material/button";
 import {MatSlideToggleModule} from "@angular/material/slide-toggle";
 import {MatIconModule} from "@angular/material/icon";
 import { NavbarComponent } from './navbar/navbar.component';
+import { MaterialModule } from 'src/infrastructure/material.module';
 
 
 
@@ -31,7 +32,8 @@ import { NavbarComponent } from './navbar/navbar.component';
     MatToolbarModule,
     MatButtonModule,
     MatSlideToggleModule,
-    MatIconModule
+    MatIconModule,
+    MaterialModule
   ]
 })
 export class NavbarModuleModule { }

--- a/Shuttle-front/src/app/navbar-module/navbar.service.spec.ts
+++ b/Shuttle-front/src/app/navbar-module/navbar.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { NavbarService } from './navbar.service';
+
+describe('NavbarService', () => {
+  let service: NavbarService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(NavbarService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/Shuttle-front/src/app/navbar-module/navbar.service.ts
+++ b/Shuttle-front/src/app/navbar-module/navbar.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+import { Observable, Subject } from 'rxjs';
+
+@Injectable({
+    providedIn: 'root'
+})
+export class NavbarService {
+    private canToggleActivity: Subject<boolean> = new Subject();
+    private refreshToggle: Subject<void> = new Subject();
+
+    constructor() { }
+
+    public getCanToggleActivity(): Observable<boolean> {
+        return this.canToggleActivity.asObservable();
+    }
+
+    public getRefreshToggle(): Observable<void> {
+        return this.refreshToggle;
+    }
+
+    public setCanToggleActivity(canToggleActivity: boolean) {
+        this.canToggleActivity.next(canToggleActivity);
+    }
+
+    public sendRefreshToggle() {
+        this.refreshToggle.next();
+    }
+}

--- a/Shuttle-front/src/app/navbar-module/navbar.service.ts
+++ b/Shuttle-front/src/app/navbar-module/navbar.service.ts
@@ -5,24 +5,15 @@ import { Observable, Subject } from 'rxjs';
     providedIn: 'root'
 })
 export class NavbarService {
-    private canToggleActivity: Subject<boolean> = new Subject();
-    private refreshToggle: Subject<void> = new Subject();
+    private activitySliderSubject: Subject<boolean> = new Subject();
 
     constructor() { }
 
-    public getCanToggleActivity(): Observable<boolean> {
-        return this.canToggleActivity.asObservable();
+    public refreshActivitySlider(canToggle: boolean) {
+        this.activitySliderSubject.next(canToggle);
     }
 
-    public getRefreshToggle(): Observable<void> {
-        return this.refreshToggle;
-    }
-
-    public setCanToggleActivity(canToggleActivity: boolean) {
-        this.canToggleActivity.next(canToggleActivity);
-    }
-
-    public sendRefreshToggle() {
-        this.refreshToggle.next();
+    public onRefreshActivitySlider(): Observable<boolean> {
+        return this.activitySliderSubject.asObservable();
     }
 }

--- a/Shuttle-front/src/app/user/user.module.ts
+++ b/Shuttle-front/src/app/user/user.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+
+
+@NgModule({
+  declarations: [],
+  imports: [
+    CommonModule
+  ]
+})
+export class UserModule { }

--- a/Shuttle-front/src/app/user/user.service.spec.ts
+++ b/Shuttle-front/src/app/user/user.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { UserService } from './user.service';
+
+describe('UserService', () => {
+  let service: UserService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(UserService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/Shuttle-front/src/app/user/user.service.ts
+++ b/Shuttle-front/src/app/user/user.service.ts
@@ -23,4 +23,11 @@ export class UserService {
             responseType: "json",
         });
     }
+
+    public getActive(id: number): Observable<boolean> {
+        return this.httpClient.get<boolean>(`${this.url}/${id}/active`, {
+            observe: "body",
+            responseType: "json",
+        });
+    }
 }

--- a/Shuttle-front/src/app/user/user.service.ts
+++ b/Shuttle-front/src/app/user/user.service.ts
@@ -1,0 +1,26 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
+
+@Injectable({
+    providedIn: 'root'
+})
+export class UserService {
+    readonly url: string = environment.serverOrigin + 'api/user'
+    constructor(private httpClient: HttpClient) { }
+
+    public setActive(id: number): Observable<any> {
+        return this.httpClient.put(`${this.url}/${id}/active`, {
+            observe: "body",
+            responseType: "json",
+        });
+    }
+
+    public setInactive(id: number): Observable<any> {
+        return this.httpClient.put(`${this.url}/${id}/inactive`, {
+            observe: "body",
+            responseType: "json",
+        });
+    }
+}


### PR DESCRIPTION
Closes #32 and #34 . See also [the pull request on the backend](https://github.com/ili0n/Shuttle-back/pull/35).

- activity set to "active" when logging in
- activity set to "inactive" when logging out
- driver can manually change his activity with the slider
- starting a ride disables changing the driver's activity and sets it to 'active'
- ending a ride enables changing the driver's activity
- driver's working hours are updated as long as he's active